### PR TITLE
Fix link for basolateral amygdala neurons publication

### DIFF
--- a/_pages/publications.md
+++ b/_pages/publications.md
@@ -39,7 +39,7 @@ AMF staff contributed in a "middle author" capacity in these papers.
 * [Functional gene delivery to and across brain vasculature of systemic AAVs with endothelial-specific tropism in rodents and broad tropism in primates](https://www.nature.com/articles/s41467-023-38582-7); Nature Communications 2023, Akrami + external collaborators, BrainSaw
 * [Cortical feedback loops bind distributed representations of working memory](https://www.nature.com/articles/s41586-022-05014-3); Nature 2022, Mrsic-Flogel, assistance with multi-photon microscopy
 * [A primary sensory cortical interareal feedforward inhibitory circuit for tacto-visual integration](https://www.biorxiv.org/content/10.1101/2022.11.04.515161v1); bioRxiv 2022, Margrie, BrainSaw
-* [Representation of ethological events by basolateral amygdala neurons](https://www.sciencedirect.com/science/article/pii/S2211124722006982#cebib0010); Cell Reports 2022, O'Keefe, BrainSaw
+* [Representation of ethological events by basolateral amygdala neurons](https://www.sciencedirect.com/science/article/pii/S2211124722006982); Cell Reports 2022, O'Keefe, BrainSaw
 * [Independent response modulation of visual cortical neurons by attentional and behavioral states](https://www.cell.com/neuron/fulltext/S0896-6273(22)00803-0#secsectitle0065); Neuron 2022, Mrsic-Flogel, Histology (RNAscope) and multi-photon assistance
 * [Accurate determination of marker location within whole-brain microscopy images](https://doi.org/10.1038/s41598-021-04676-9); Scientific Reports 2022, Margrie, BrainSaw
 * [A deep learning algorithm for 3D cell detection in whole mouse brain image datasets](https://doi.org/10.1371/journal.pcbi.1009074); PLOS Comp Bio 2021, Margrie, BrainSaw, TissueVision


### PR DESCRIPTION
Fix typo in link for Representation of ethological events by basolateral amygdala neurons.

Original link pointed to a specific part of the references. The new link points directly to the article.